### PR TITLE
Add Status to Items

### DIFF
--- a/lib/todo/notebook/item.ex
+++ b/lib/todo/notebook/item.ex
@@ -16,4 +16,11 @@ defmodule Todo.Notebook.Item do
     |> cast(attrs, [:description, :user_id, :status])
     |> validate_required([:description, :user_id, :status])
   end
+
+  def pretty_status(item) do
+    case item.status do
+      :todo -> "To Do"
+      :done -> "Done"
+    end
+  end
 end

--- a/lib/todo/notebook/item.ex
+++ b/lib/todo/notebook/item.ex
@@ -5,6 +5,7 @@ defmodule Todo.Notebook.Item do
   schema "items" do
     field :description, :string
     field :user_id, :id
+    field :status, Ecto.Enum, values: [:todo, :done]
 
     timestamps()
   end
@@ -12,7 +13,7 @@ defmodule Todo.Notebook.Item do
   @doc false
   def changeset(item, attrs) do
     item
-    |> cast(attrs, [:description, :user_id])
-    |> validate_required([:description, :user_id])
+    |> cast(attrs, [:description, :user_id, :status])
+    |> validate_required([:description, :user_id, :status])
   end
 end

--- a/lib/todo_web/live/item_live/form_component.html.heex
+++ b/lib/todo_web/live/item_live/form_component.html.heex
@@ -15,6 +15,10 @@
     <%= text_input f, :description %>
     <%= error_tag f, :description %>
 
+    <%= label f, :status %>
+    <%= select f, :status, ["To Do": :todo, "Done": :done] %>
+    <%= error_tag f, :status %>
+
     <div>
       <%= submit "Save", phx_disable_with: "Saving..." %>
     </div>

--- a/lib/todo_web/live/item_live/index.html.heex
+++ b/lib/todo_web/live/item_live/index.html.heex
@@ -18,7 +18,7 @@
   <thead>
     <tr>
       <th>Description</th>
-
+      <th>Status</th>
       <th></th>
     </tr>
   </thead>
@@ -26,7 +26,7 @@
     <%= for item <- @items do %>
       <tr id={"item-#{item.id}"}>
         <td><%= item.description %></td>
-
+        <td><%= Item.pretty_status(item) %></td>
         <td>
           <span><%= live_redirect "Show", to: Routes.item_show_path(@socket, :show, item) %></span>
           <span><%= live_patch "Edit", to: Routes.item_index_path(@socket, :edit, item) %></span>

--- a/lib/todo_web/live/item_live/show.ex
+++ b/lib/todo_web/live/item_live/show.ex
@@ -2,6 +2,7 @@ defmodule TodoWeb.ItemLive.Show do
   use TodoWeb, :live_view
 
   alias Todo.Notebook
+  alias Todo.Notebook.Item
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/todo_web/live/item_live/show.html.heex
+++ b/lib/todo_web/live/item_live/show.html.heex
@@ -20,6 +20,10 @@
     <strong>Description:</strong>
     <%= @item.description %>
   </li>
+  <li>
+    <strong>Status:</strong>
+    <%= Item.pretty_status(@item) %>
+  </li>
 
 </ul>
 

--- a/priv/repo/migrations/20220928001719_add_status_to_items.exs
+++ b/priv/repo/migrations/20220928001719_add_status_to_items.exs
@@ -1,0 +1,7 @@
+defmodule Todo.Repo.Migrations.AddStatusToItems do
+  use Ecto.Migration
+
+  def change do
+
+  end
+end

--- a/priv/repo/migrations/20220928001719_add_status_to_items.exs
+++ b/priv/repo/migrations/20220928001719_add_status_to_items.exs
@@ -2,6 +2,8 @@ defmodule Todo.Repo.Migrations.AddStatusToItems do
   use Ecto.Migration
 
   def change do
-
+    alter table(:items) do
+      add :status, :string, default: "todo", null: false
+    end
   end
 end

--- a/test/support/fixtures/notebook_fixtures.ex
+++ b/test/support/fixtures/notebook_fixtures.ex
@@ -13,7 +13,8 @@ defmodule Todo.NotebookFixtures do
     combined_attrs =
       attrs
       |> Enum.into(%{
-        "description" => "some description"
+        "description" => "some description",
+        "status" => :done
       })
 
     {:ok, item} = Todo.Notebook.create_item(user_id, combined_attrs)

--- a/test/todo/notebook_test.exs
+++ b/test/todo/notebook_test.exs
@@ -21,7 +21,7 @@ defmodule Todo.NotebookTest do
     end
 
     test "create_item/1 with valid data creates a item", %{user: user} do
-      valid_attrs = %{ "description" => "some description", "user_id" => user.id}
+      valid_attrs = %{ "description" => "some description", "user_id" => user.id, "status" => :todo}
 
       assert {:ok, %Item{} = item} = Notebook.create_item(user.id, valid_attrs)
       assert item.description == "some description"

--- a/test/todo/notebook_test.exs
+++ b/test/todo/notebook_test.exs
@@ -36,7 +36,7 @@ defmodule Todo.NotebookTest do
       assert {:error, %Ecto.Changeset{}} = Notebook.create_item(user.id, %{"description" => "A valid description", "user_id" => user.id, "status" => :groggle})
     end
 
-    test "update_item/2 with valid data updates the item", %{user: user} do
+    test "update_item/2 with valid description updates the item", %{user: user} do
       item = item_fixture(%{"user_id" => user.id})
       update_attrs = %{"description" => "some updated description", "user_id" => user.id}
 
@@ -44,9 +44,23 @@ defmodule Todo.NotebookTest do
       assert item.description == "some updated description"
     end
 
-    test "update_item/2 with invalid data returns error changeset", %{user: user} do
+    test "update_item/2 with valid status updates the item", %{user: user} do
+      item = item_fixture(%{"user_id" => user.id})
+      update_attrs = %{"status" => :done, "user_id" => user.id}
+
+      assert {:ok, %Item{} = item} = Notebook.update_item(user.id, item, update_attrs)
+      assert item.status == :done
+    end
+
+    test "update_item/2 with invalid description returns error changeset", %{user: user} do
       item = item_fixture(%{"user_id" => user.id})
       assert {:error, %Ecto.Changeset{}} = Notebook.update_item(user.id, item, %{"description" => nil, "user_id" => user.id})
+      assert item == Notebook.get_item!(item.id, user.id)
+    end
+
+    test "update_item/2 with invalid status returns error changeset", %{user: user} do
+      item = item_fixture(%{"user_id" => user.id})
+      assert {:error, %Ecto.Changeset{}} = Notebook.update_item(user.id, item, %{"status" => nil, "user_id" => user.id})
       assert item == Notebook.get_item!(item.id, user.id)
     end
 

--- a/test/todo/notebook_test.exs
+++ b/test/todo/notebook_test.exs
@@ -27,8 +27,12 @@ defmodule Todo.NotebookTest do
       assert item.description == "some description"
     end
 
-    test "create_item/1 with invalid data returns error changeset", %{user: user} do
-      assert {:error, %Ecto.Changeset{}} = Notebook.create_item(user.id, %{"description" => nil, "user_id" => user.id})
+    test "create_item/1 with invalid description returns error changeset", %{user: user} do
+      assert {:error, %Ecto.Changeset{}} = Notebook.create_item(user.id, %{"description" => nil, "user_id" => user.id, "status" => :todo})
+    end
+
+    test "create_item/1 with invalid status returns error changeset", %{user: user} do
+      assert {:error, %Ecto.Changeset{}} = Notebook.create_item(user.id, %{"description" => "A valid description", "user_id" => user.id, "status" => :groggle})
     end
 
     test "update_item/2 with valid data updates the item", %{user: user} do

--- a/test/todo/notebook_test.exs
+++ b/test/todo/notebook_test.exs
@@ -25,6 +25,7 @@ defmodule Todo.NotebookTest do
 
       assert {:ok, %Item{} = item} = Notebook.create_item(user.id, valid_attrs)
       assert item.description == "some description"
+      assert item.status == :todo
     end
 
     test "create_item/1 with invalid description returns error changeset", %{user: user} do


### PR DESCRIPTION
This PR adds a `status` field to the `items` table. The two options available for now are `:todo` and `:done`. These values are stored as strings in the database, but they can be matched as atoms in the Elixir code. These values can be set on creation of a new item or update of an existing item. The status is also displayed along with the description wherever an item can be found on a page. Finally, the PR improves test coverage by adding some new tests to specifically check for valid & invalid statuses within the `create_item/1` and `update_item/2` functions.

Resolves #3.