### PR TITLE
Update items on other browser instances in real-time

### DIFF
--- a/lib/todo/notebook.ex
+++ b/lib/todo/notebook.ex
@@ -130,7 +130,9 @@ defmodule Todo.Notebook do
     # This ensures the item belongs to the user.
     %Item{ user_id: ^user_id } = item
 
-    Repo.delete(item)
+    item
+    |> Repo.delete()
+    |> broadcast(:item_deleted)
   end
 
   @doc """

--- a/lib/todo/notebook.ex
+++ b/lib/todo/notebook.ex
@@ -19,7 +19,8 @@ defmodule Todo.Notebook do
   """
   def list_items_by_user(user_id) do
     query = from i in Item,
-            where: i.user_id == ^user_id
+            where: i.user_id == ^user_id,
+            order_by: [desc: i.id]
 
     Repo.all(query)
   end

--- a/lib/todo/notebook.ex
+++ b/lib/todo/notebook.ex
@@ -74,6 +74,7 @@ defmodule Todo.Notebook do
     %Item{}
     |> Item.changeset(attrs)
     |> Repo.insert()
+    |> broadcast(:item_created)
   end
 
   @doc """
@@ -104,6 +105,7 @@ defmodule Todo.Notebook do
     item
     |> Item.changeset(attrs)
     |> Repo.update()
+    |> broadcast(:item_updated)
   end
 
   @doc """
@@ -142,4 +144,15 @@ defmodule Todo.Notebook do
   def change_item(%Item{} = item, attrs \\ %{}) do
     Item.changeset(item, attrs)
   end
+
+  def subscribe do
+    Phoenix.PubSub.subscribe(Todo.PubSub, "items")
+  end
+
+  defp broadcast({:error, _reason} = error, _event), do: error
+  defp broadcast({:ok, item}, event) do
+    Phoenix.PubSub.broadcast(Todo.PubSub, "items", {event, item})
+    {:ok, item}
+  end
+
 end

--- a/lib/todo_web/live/item_live/index.ex
+++ b/lib/todo_web/live/item_live/index.ex
@@ -8,6 +8,8 @@ defmodule TodoWeb.ItemLive.Index do
   def mount(_params, _session, socket) do
     user_id = socket.assigns.current_user.id
 
+    if connected?(socket), do: Notebook.subscribe()
+
     {:ok, assign(socket, :items, list_items(user_id))}
   end
 
@@ -44,6 +46,11 @@ defmodule TodoWeb.ItemLive.Index do
     {:ok, _} = Notebook.delete_item(user_id, item)
 
     {:noreply, assign(socket, :items, list_items(user_id))}
+  end
+
+  @impl true
+  def handle_info({:item_created, item}, socket) do
+    {:noreply, update(socket, :items, fn items -> [item | items] end)}
   end
 
   defp list_items(user_id) do

--- a/lib/todo_web/live/item_live/index.ex
+++ b/lib/todo_web/live/item_live/index.ex
@@ -10,7 +10,7 @@ defmodule TodoWeb.ItemLive.Index do
 
     if connected?(socket), do: Notebook.subscribe()
 
-    {:ok, assign(socket, :items, list_items(user_id))}
+    {:ok, assign(socket, :items, list_items(user_id)), temporary_assigns: [items: []]}
   end
 
   @impl true
@@ -50,6 +50,10 @@ defmodule TodoWeb.ItemLive.Index do
 
   @impl true
   def handle_info({:item_created, item}, socket) do
+    {:noreply, update(socket, :items, fn items -> [item | items] end)}
+  end
+
+  def handle_info({:item_updated, item}, socket) do
     {:noreply, update(socket, :items, fn items -> [item | items] end)}
   end
 

--- a/lib/todo_web/live/item_live/index.ex
+++ b/lib/todo_web/live/item_live/index.ex
@@ -45,7 +45,7 @@ defmodule TodoWeb.ItemLive.Index do
     item = Notebook.get_item!(id, user_id)
     {:ok, _} = Notebook.delete_item(user_id, item)
 
-    {:noreply, assign(socket, :items, list_items(user_id))}
+    {:noreply, socket}
   end
 
   @impl true
@@ -68,9 +68,18 @@ defmodule TodoWeb.ItemLive.Index do
   defp update_items(operation, items, item) do
     index = Enum.find_index(items, fn i -> item.id == i.id end)
 
-    case operation do
-      :replace -> List.replace_at(items, index, item)
-      :remove -> List.delete_at(items, index)
+    # If the event occurs on the same browser instance that
+    # performed the action, we will have already reloaded
+    # the items from the update/delete event.
+    case index do
+      nil -> items
+      i ->
+        case operation do
+          :replace -> List.replace_at(items, i, item)
+          :remove -> List.delete_at(items, i)
+        end
     end
+
+
   end
 end

--- a/lib/todo_web/live/item_live/index.ex
+++ b/lib/todo_web/live/item_live/index.ex
@@ -8,7 +8,7 @@ defmodule TodoWeb.ItemLive.Index do
   def mount(_params, _session, socket) do
     user_id = socket.assigns.current_user.id
 
-    if connected?(socket), do: Notebook.subscribe()
+    if connected?(socket), do: Notebook.subscribe(user_id)
 
     {:ok, assign(socket, :items, list_items(user_id))}
   end

--- a/lib/todo_web/live/item_live/index.html.heex
+++ b/lib/todo_web/live/item_live/index.html.heex
@@ -22,7 +22,7 @@
       <th></th>
     </tr>
   </thead>
-  <tbody id="items">
+  <tbody id="items" phx-update="prepend">
     <%= for item <- @items do %>
       <tr id={"item-#{item.id}"}>
         <td><%= item.description %></td>

--- a/lib/todo_web/live/item_live/index.html.heex
+++ b/lib/todo_web/live/item_live/index.html.heex
@@ -22,7 +22,7 @@
       <th></th>
     </tr>
   </thead>
-  <tbody id="items" phx-update="prepend">
+  <tbody id="items" phx-update="replace">
     <%= for item <- @items do %>
       <tr id={"item-#{item.id}"}>
         <td><%= item.description %></td>


### PR DESCRIPTION
When the user is logged in on two (or more) devices, we want changes on one device to be immediately reflected on the other. This PR adds functionality to send real-time notifications on item creation, updates, and deletes so that the other device can immediately reflect the new state without requiring a manual refresh.

Of course, we don't want different users to get notifications from one another, so there's a bit of code here to restrict notifications to only the user who created the event. In practice, this means the user joins a topic that corresponds to the user's `id`.

Resolves #22.