### PR TITLE
Reorder items appropriately on a realtime event

### DIFF
--- a/lib/todo/notebook.ex
+++ b/lib/todo/notebook.ex
@@ -158,7 +158,7 @@ defmodule Todo.Notebook do
   defp broadcast({:error, _reason} = error, _event), do: error
 
   defp broadcast({:ok, item}, {event, user_id}) do
-    Phoenix.PubSub.broadcast(Todo.PubSub, items_topic(user_id), {event, user_id, item})
+    Phoenix.PubSub.broadcast(Todo.PubSub, items_topic(user_id), {event, user_id})
     {:ok, item}
   end
 end

--- a/lib/todo/notebook.ex
+++ b/lib/todo/notebook.ex
@@ -158,7 +158,7 @@ defmodule Todo.Notebook do
   defp broadcast({:error, _reason} = error, _event), do: error
 
   defp broadcast({:ok, item}, {event, user_id}) do
-    Phoenix.PubSub.broadcast(Todo.PubSub, items_topic(user_id), {event, item})
+    Phoenix.PubSub.broadcast(Todo.PubSub, items_topic(user_id), {event, user_id, item})
     {:ok, item}
   end
 end

--- a/lib/todo_web/live/item_live/index.ex
+++ b/lib/todo_web/live/item_live/index.ex
@@ -49,15 +49,15 @@ defmodule TodoWeb.ItemLive.Index do
   end
 
   @impl true
-  def handle_info({:item_created, user_id, _}, socket) do
+  def handle_info({:item_created, user_id}, socket) do
     {:noreply, update(socket, :items, fn _ -> list_items(user_id) end)}
   end
 
-  def handle_info({:item_updated, user_id, _}, socket) do
+  def handle_info({:item_updated, user_id}, socket) do
     {:noreply, update(socket, :items, fn _ -> list_items(user_id) end)}
   end
 
-  def handle_info({:item_deleted, user_id, _}, socket) do
+  def handle_info({:item_deleted, user_id}, socket) do
     {:noreply, update(socket, :items, fn _ -> list_items(user_id) end)}
   end
 

--- a/lib/todo_web/live/item_live/index.ex
+++ b/lib/todo_web/live/item_live/index.ex
@@ -49,37 +49,19 @@ defmodule TodoWeb.ItemLive.Index do
   end
 
   @impl true
-  def handle_info({:item_created, item}, socket) do
-    {:noreply, update(socket, :items, fn items -> [item | items] end)}
+  def handle_info({:item_created, user_id, item}, socket) do
+    {:noreply, update(socket, :items, fn _ -> list_items(user_id) end)}
   end
 
-  def handle_info({:item_updated, item}, socket) do
-    {:noreply, update(socket, :items, fn items -> update_items(:replace, items, item) end)}
+  def handle_info({:item_updated, user_id, item}, socket) do
+    {:noreply, update(socket, :items, fn _ -> list_items(user_id) end)}
   end
 
-  def handle_info({:item_deleted, item}, socket) do
-    {:noreply, update(socket, :items, fn items -> update_items(:remove, items, item) end)}
+  def handle_info({:item_deleted, user_id, item}, socket) do
+    {:noreply, update(socket, :items, fn _ -> list_items(user_id) end)}
   end
 
   defp list_items(user_id) do
     Notebook.list_items_by_user(user_id)
-  end
-
-  defp update_items(operation, items, item) do
-    index = Enum.find_index(items, fn i -> item.id == i.id end)
-
-    # If the event occurs on the same browser instance that
-    # performed the action, we will have already reloaded
-    # the items from the update/delete event.
-    case index do
-      nil ->
-        items
-
-      i ->
-        case operation do
-          :replace -> List.replace_at(items, i, item)
-          :remove -> List.delete_at(items, i)
-        end
-    end
   end
 end

--- a/lib/todo_web/live/item_live/index.ex
+++ b/lib/todo_web/live/item_live/index.ex
@@ -49,15 +49,15 @@ defmodule TodoWeb.ItemLive.Index do
   end
 
   @impl true
-  def handle_info({:item_created, user_id, item}, socket) do
+  def handle_info({:item_created, user_id, _}, socket) do
     {:noreply, update(socket, :items, fn _ -> list_items(user_id) end)}
   end
 
-  def handle_info({:item_updated, user_id, item}, socket) do
+  def handle_info({:item_updated, user_id, _}, socket) do
     {:noreply, update(socket, :items, fn _ -> list_items(user_id) end)}
   end
 
-  def handle_info({:item_deleted, user_id, item}, socket) do
+  def handle_info({:item_deleted, user_id, _}, socket) do
     {:noreply, update(socket, :items, fn _ -> list_items(user_id) end)}
   end
 


### PR DESCRIPTION
This is easily accomplished by asking the database for an up-to-date copy in the correct order.

Fixes #34.