### PR TITLE
Add timezone field to users table to resolve due date highlighting bug

### DIFF
--- a/lib/todo/accounts.ex
+++ b/lib/todo/accounts.ex
@@ -214,7 +214,48 @@ defmodule Todo.Accounts do
       {:error, :user, changeset, _} -> {:error, changeset}
     end
   end
+  
+  @doc """
+  Returns an `%Ecto.Changeset{}` for changing the user timezone.
 
+  ## Examples
+
+      iex> change_user_timezone(user)
+      %Ecto.Changeset{data: %User{}}
+
+  """
+  def change_user_timezone(user, attrs \\ %{}) do
+    User.timezone_changeset(user, attrs)
+  end
+
+  @doc """
+  Updates the user timezone.
+
+  ## Examples
+
+      iex> update_user_timezone(user, "valid password", %{password: ...})
+      {:ok, %User{}}
+
+      iex> update_user_timezone(user, "invalid password", %{password: ...})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_user_timezone(user, password, attrs) do
+    changeset =
+      user
+      |> User.timezone_changeset(attrs)
+      |> User.validate_current_password(password)
+
+    Ecto.Multi.new()
+    |> Ecto.Multi.update(:user, changeset)
+    |> Ecto.Multi.delete_all(:tokens, UserToken.user_and_contexts_query(user, :all))
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{user: user}} -> {:ok, user}
+      {:error, :user, changeset, _} -> {:error, changeset}
+    end
+  end
+  
   ## Session
 
   @doc """

--- a/lib/todo/accounts.ex
+++ b/lib/todo/accounts.ex
@@ -214,7 +214,7 @@ defmodule Todo.Accounts do
       {:error, :user, changeset, _} -> {:error, changeset}
     end
   end
-  
+
   @doc """
   Returns an `%Ecto.Changeset{}` for changing the user timezone.
 
@@ -255,7 +255,7 @@ defmodule Todo.Accounts do
       {:error, :user, changeset, _} -> {:error, changeset}
     end
   end
-  
+
   ## Session
 
   @doc """

--- a/lib/todo/accounts/user.ex
+++ b/lib/todo/accounts/user.ex
@@ -103,7 +103,7 @@ defmodule Todo.Accounts.User do
     |> validate_confirmation(:password, message: "does not match password")
     |> validate_password(opts)
   end
-  
+
   @doc """
   A user changeset for changing the timezone.
 
@@ -117,7 +117,6 @@ defmodule Todo.Accounts.User do
       %{} = changeset -> add_error(changeset, :timezone, "did not change")
     end
   end
- 
 
   @doc """
   Confirms the account by setting `confirmed_at`.

--- a/lib/todo/accounts/user.ex
+++ b/lib/todo/accounts/user.ex
@@ -7,6 +7,7 @@ defmodule Todo.Accounts.User do
     field :password, :string, virtual: true, redact: true
     field :hashed_password, :string, redact: true
     field :confirmed_at, :naive_datetime
+    field :timezone, :string
 
     timestamps()
   end
@@ -102,6 +103,21 @@ defmodule Todo.Accounts.User do
     |> validate_confirmation(:password, message: "does not match password")
     |> validate_password(opts)
   end
+  
+  @doc """
+  A user changeset for changing the timezone.
+
+  It requires the timezone to change otherwise an error is added.
+  """
+  def timezone_changeset(user, attrs) do
+    user
+    |> cast(attrs, [:timezone])
+    |> case do
+      %{changes: %{timezone: _}} = changeset -> changeset
+      %{} = changeset -> add_error(changeset, :timezone, "did not change")
+    end
+  end
+ 
 
   @doc """
   Confirms the account by setting `confirmed_at`.

--- a/lib/todo_web/controllers/user_settings_controller.ex
+++ b/lib/todo_web/controllers/user_settings_controller.ex
@@ -49,6 +49,23 @@ defmodule TodoWeb.UserSettingsController do
         render(conn, "edit.html", password_changeset: changeset)
     end
   end
+  
+  def update(conn, %{"action" => "update_timezone"} = params) do
+    %{"current_password" => password, "user" => user_params} = params
+    user = conn.assigns.current_user
+
+    case Accounts.update_user_timezone(user, password, user_params) do
+      {:ok, user} ->
+        conn
+        |> put_flash(:info, "Timezone updated successfully.")
+        |> put_session(:user_return_to, Routes.user_settings_path(conn, :edit))
+        |> UserAuth.log_in_user(user)
+
+      {:error, changeset} ->
+        render(conn, "edit.html", timezone_changeset: changeset)
+    end
+  end
+
 
   def confirm_email(conn, %{"token" => token}) do
     case Accounts.update_user_email(conn.assigns.current_user, token) do
@@ -70,5 +87,6 @@ defmodule TodoWeb.UserSettingsController do
     conn
     |> assign(:email_changeset, Accounts.change_user_email(user))
     |> assign(:password_changeset, Accounts.change_user_password(user))
+    |> assign(:timezone_changeset, Accounts.change_user_timezone(user))
   end
 end

--- a/lib/todo_web/controllers/user_settings_controller.ex
+++ b/lib/todo_web/controllers/user_settings_controller.ex
@@ -49,7 +49,7 @@ defmodule TodoWeb.UserSettingsController do
         render(conn, "edit.html", password_changeset: changeset)
     end
   end
-  
+
   def update(conn, %{"action" => "update_timezone"} = params) do
     %{"current_password" => password, "user" => user_params} = params
     user = conn.assigns.current_user
@@ -65,7 +65,6 @@ defmodule TodoWeb.UserSettingsController do
         render(conn, "edit.html", timezone_changeset: changeset)
     end
   end
-
 
   def confirm_email(conn, %{"token" => token}) do
     case Accounts.update_user_email(conn.assigns.current_user, token) do

--- a/lib/todo_web/live/item_live/index.ex
+++ b/lib/todo_web/live/item_live/index.ex
@@ -10,11 +10,8 @@ defmodule TodoWeb.ItemLive.Index do
 
     if connected?(socket), do: Notebook.subscribe(user_id)
 
-    local_date = Timex.local() |> Timex.to_date()
-
     socket =
       socket
-      |> assign(:local_date, local_date)
       |> assign(:items, list_items(user_id))
 
     {:ok, socket}

--- a/lib/todo_web/live/item_live/index.html.heex
+++ b/lib/todo_web/live/item_live/index.html.heex
@@ -19,7 +19,7 @@
 
   <div id="items" phx-update="replace" class='flex flex-row flex-wrap justify-center w-full'>
     <%= for item <- @items do %>
-      <.live_component module={ItemComponent} id={"item-#{item.id}"} item={item} local_date={@local_date} />
+      <.live_component module={ItemComponent} id={"item-#{item.id}"} item={item} timezone={@current_user.timezone} />
     <% end %>
   </div>
 </section>

--- a/lib/todo_web/live/item_live/item_component.ex
+++ b/lib/todo_web/live/item_live/item_component.ex
@@ -2,7 +2,9 @@ defmodule ItemComponent do
   use TodoWeb, :live_component
   alias Todo.Notebook.Item
 
-  def compare_date(due_date, local_date) do
+  def compare_date(due_date, timezone) do
+    local_date = Timex.now(timezone)
+
     val = Date.compare(due_date, local_date)
 
     case val do

--- a/lib/todo_web/live/item_live/item_component.ex
+++ b/lib/todo_web/live/item_live/item_component.ex
@@ -3,11 +3,12 @@ defmodule ItemComponent do
   alias Todo.Notebook.Item
 
   def compare_date(due_date, timezone) do
-    case timezone do
-      nil -> ""
-      tz -> 
-        local_date = Timex.now(timezone)
-
+    local_date = Timex.now(timezone)
+    
+    case local_date do
+      {:error, _} -> ""
+      _ ->
+        
         val = Date.compare(due_date, local_date)
 
         case val do
@@ -15,6 +16,7 @@ defmodule ItemComponent do
           :eq -> "font-bold text-orange-500"
           :gt -> ""
         end
+ 
     end
   end
 end

--- a/lib/todo_web/live/item_live/item_component.ex
+++ b/lib/todo_web/live/item_live/item_component.ex
@@ -4,11 +4,12 @@ defmodule ItemComponent do
 
   def compare_date(due_date, timezone) do
     local_date = Timex.now(timezone)
-    
+
     case local_date do
-      {:error, _} -> ""
+      {:error, _} ->
+        ""
+
       _ ->
-        
         val = Date.compare(due_date, local_date)
 
         case val do
@@ -16,7 +17,6 @@ defmodule ItemComponent do
           :eq -> "font-bold text-orange-500"
           :gt -> ""
         end
- 
     end
   end
 end

--- a/lib/todo_web/live/item_live/item_component.ex
+++ b/lib/todo_web/live/item_live/item_component.ex
@@ -3,14 +3,18 @@ defmodule ItemComponent do
   alias Todo.Notebook.Item
 
   def compare_date(due_date, timezone) do
-    local_date = Timex.now(timezone)
+    case timezone do
+      nil -> ""
+      tz -> 
+        local_date = Timex.now(timezone)
 
-    val = Date.compare(due_date, local_date)
+        val = Date.compare(due_date, local_date)
 
-    case val do
-      :lt -> "font-bold text-red-500"
-      :eq -> "font-bold text-orange-500"
-      :gt -> ""
+        case val do
+          :lt -> "font-bold text-red-500"
+          :eq -> "font-bold text-orange-500"
+          :gt -> ""
+        end
     end
   end
 end

--- a/lib/todo_web/live/item_live/item_component.html.heex
+++ b/lib/todo_web/live/item_live/item_component.html.heex
@@ -3,7 +3,7 @@
     <div><%= @item.description %></div>
     <div class='mt-1'>
       <strong>Due</strong>
-      <span class={ItemComponent.compare_date(@item.due_date, @local_date)}> 
+      <span class={ItemComponent.compare_date(@item.due_date, @timezone)}> 
         <%= Todo.Date.pretty_date(@item.due_date) %>
       </span>
     </div>

--- a/lib/todo_web/templates/user_settings/edit.html.heex
+++ b/lib/todo_web/templates/user_settings/edit.html.heex
@@ -51,3 +51,26 @@
     <%= submit "Change password" %>
   </div>
 </.form>
+
+<.form let={f} for={@timezone_changeset} action={Routes.user_settings_path(@conn, :update)} id="update_timezone">
+  <%= if @timezone_changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <%= hidden_input f, :action, name: "action", value: "update_timezone" %>
+
+  <%= label f, :timezone %>
+  <%= select f, :timezone, options: Timex.timezones() %>
+  <%= error_tag f, :timezone %>
+
+  <%= label f, :current_password, for: "current_password_for_timezone" %>
+  <%= password_input f, :current_password, required: true, name: "current_password", id: "current_password_for_timezone" %>
+  <%= error_tag f, :current_password %>
+
+  <div>
+    <%= submit "Change timezone" %>
+  </div>
+</.form>
+

--- a/priv/repo/migrations/20221104001712_add_timezone_to_users.exs
+++ b/priv/repo/migrations/20221104001712_add_timezone_to_users.exs
@@ -1,0 +1,7 @@
+defmodule Todo.Repo.Migrations.AddTimezoneToUsers do
+  use Ecto.Migration
+
+  def change do
+
+  end
+end

--- a/priv/repo/migrations/20221104001712_add_timezone_to_users.exs
+++ b/priv/repo/migrations/20221104001712_add_timezone_to_users.exs
@@ -2,6 +2,8 @@ defmodule Todo.Repo.Migrations.AddTimezoneToUsers do
   use Ecto.Migration
 
   def change do
-
+    alter table(:users) do
+      add :timezone, :string, null: true
+    end
   end
 end

--- a/test/todo_web/controllers/user_settings_controller_test.exs
+++ b/test/todo_web/controllers/user_settings_controller_test.exs
@@ -88,7 +88,7 @@ defmodule TodoWeb.UserSettingsControllerTest do
       assert response =~ "is not valid"
     end
   end
-  
+
   describe "PUT /users/settings (change timezone form)" do
     test "updates the user timezone and resets tokens", %{conn: conn, user: user} do
       new_conn =
@@ -96,14 +96,14 @@ defmodule TodoWeb.UserSettingsControllerTest do
           "action" => "update_timezone",
           "current_password" => valid_user_password(),
           "user" => %{
-            "timezone" => "America/Phoenix",
+            "timezone" => "America/Phoenix"
           }
         })
 
       assert redirected_to(new_conn) == Routes.user_settings_path(conn, :edit)
       assert get_session(new_conn, :user_token) != get_session(conn, :user_token)
       assert get_flash(new_conn, :info) =~ "Timezone updated successfully"
-      
+
       new_user = Accounts.get_user_by_email(user.email)
 
       assert new_user.timezone == "America/Phoenix"
@@ -115,7 +115,7 @@ defmodule TodoWeb.UserSettingsControllerTest do
           "action" => "update_timezone",
           "current_password" => "invalid",
           "user" => %{
-            "timezone" => "America/Phoenix",
+            "timezone" => "America/Phoenix"
           }
         })
 

--- a/test/todo_web/controllers/user_settings_controller_test.exs
+++ b/test/todo_web/controllers/user_settings_controller_test.exs
@@ -88,6 +88,27 @@ defmodule TodoWeb.UserSettingsControllerTest do
       assert response =~ "is not valid"
     end
   end
+  
+  describe "PUT /users/settings (change timezone form)" do
+    test "updates the user timezone and resets tokens", %{conn: conn, user: user} do
+      new_password_conn =
+        put(conn, Routes.user_settings_path(conn, :update), %{
+          "action" => "update_timezone",
+          "current_password" => valid_user_password(),
+          "user" => %{
+            "timezone" => "America/Phoenix",
+          }
+        })
+
+      assert redirected_to(new_password_conn) == Routes.user_settings_path(conn, :edit)
+      assert get_session(new_password_conn, :user_token) != get_session(conn, :user_token)
+      assert get_flash(new_password_conn, :info) =~ "Timezone updated successfully"
+      
+      new_user = Accounts.get_user_by_email(user.email)
+
+      assert new_user.timezone == "America/Phoenix"
+    end
+  end
 
   describe "GET /users/settings/confirm_email/:token" do
     setup %{user: user} do

--- a/test/todo_web/controllers/user_settings_controller_test.exs
+++ b/test/todo_web/controllers/user_settings_controller_test.exs
@@ -91,7 +91,7 @@ defmodule TodoWeb.UserSettingsControllerTest do
   
   describe "PUT /users/settings (change timezone form)" do
     test "updates the user timezone and resets tokens", %{conn: conn, user: user} do
-      new_password_conn =
+      new_conn =
         put(conn, Routes.user_settings_path(conn, :update), %{
           "action" => "update_timezone",
           "current_password" => valid_user_password(),
@@ -100,13 +100,34 @@ defmodule TodoWeb.UserSettingsControllerTest do
           }
         })
 
-      assert redirected_to(new_password_conn) == Routes.user_settings_path(conn, :edit)
-      assert get_session(new_password_conn, :user_token) != get_session(conn, :user_token)
-      assert get_flash(new_password_conn, :info) =~ "Timezone updated successfully"
+      assert redirected_to(new_conn) == Routes.user_settings_path(conn, :edit)
+      assert get_session(new_conn, :user_token) != get_session(conn, :user_token)
+      assert get_flash(new_conn, :info) =~ "Timezone updated successfully"
       
       new_user = Accounts.get_user_by_email(user.email)
 
       assert new_user.timezone == "America/Phoenix"
+    end
+
+    test "does not update timezone on invalid data", %{conn: conn, user: user} do
+      new_conn =
+        put(conn, Routes.user_settings_path(conn, :update), %{
+          "action" => "update_timezone",
+          "current_password" => "invalid",
+          "user" => %{
+            "timezone" => "America/Phoenix",
+          }
+        })
+
+      response = html_response(new_conn, 200)
+      assert response =~ "<h1>Settings</h1>"
+      assert response =~ "is not valid"
+
+      assert get_session(new_conn, :user_token) == get_session(conn, :user_token)
+
+      new_user = Accounts.get_user_by_email(user.email)
+
+      assert new_user.timezone == nil
     end
   end
 

--- a/test/todo_web/live/item_component_test.exs
+++ b/test/todo_web/live/item_component_test.exs
@@ -1,0 +1,33 @@
+defmodule TodoWeb.ItemComponentTest do
+
+  use ExUnit.Case, async: true
+  
+  setup_all do
+    timezone = "America/Phoenix"
+    today = Timex.today(timezone)
+
+    [today: today, timezone: timezone]
+  end
+
+  describe "compare_date" do
+    test "should return no styles with a nil timezone", context do
+      assert ItemComponent.compare_date(context[:today], nil) == ""
+    end
+
+    test "should return a bold red style for an item past its due date", context do
+      yesterday = context[:today] |> Timex.shift(days: -1)
+
+      assert ItemComponent.compare_date(yesterday, context[:timezone]) == "font-bold text-red-500"
+    end
+
+    test "should return a bold orange style for an item due today", context do
+      assert ItemComponent.compare_date(context[:today], context[:timezone]) == "font-bold text-orange-500"
+    end
+
+    test "should return no style for an item due in the future", context do
+      tomorrow = context[:today] |> Timex.shift(days: 1)
+
+      assert ItemComponent.compare_date(tomorrow, context[:timezone]) == ""
+    end
+  end
+end

--- a/test/todo_web/live/item_component_test.exs
+++ b/test/todo_web/live/item_component_test.exs
@@ -1,7 +1,6 @@
 defmodule TodoWeb.ItemComponentTest do
-
   use ExUnit.Case, async: true
-  
+
   setup_all do
     timezone = "America/Phoenix"
     today = Timex.today(timezone)
@@ -21,7 +20,8 @@ defmodule TodoWeb.ItemComponentTest do
     end
 
     test "should return a bold orange style for an item due today", context do
-      assert ItemComponent.compare_date(context[:today], context[:timezone]) == "font-bold text-orange-500"
+      assert ItemComponent.compare_date(context[:today], context[:timezone]) ==
+               "font-bold text-orange-500"
     end
 
     test "should return no style for an item due in the future", context do


### PR DESCRIPTION
Users can now set the `timezone` field on the user settings page. This will compare the due date accurately to the user's local time so that the due date highlighting will show up accurately.

Fixes #39.