### PR TITLE
Default a new item's due date to today

### DIFF
--- a/lib/todo_web/live/item_live/index.ex
+++ b/lib/todo_web/live/item_live/index.ex
@@ -31,8 +31,13 @@ defmodule TodoWeb.ItemLive.Index do
   end
 
   defp apply_action(socket, :new, _params) do
+    # Default to UTC if the user hasn't set the timezone setting.
+    timezone = case socket.assigns.current_user.timezone do
+      nil -> "UTC"
+      tz -> tz
+    end
+
     # Default the new item's due date to today.
-    timezone = socket.assigns.current_user.timezone
     today = DateTime.to_date(Timex.now(timezone))
     item = %Item{due_date: today}
 

--- a/lib/todo_web/live/item_live/index.ex
+++ b/lib/todo_web/live/item_live/index.ex
@@ -32,10 +32,11 @@ defmodule TodoWeb.ItemLive.Index do
 
   defp apply_action(socket, :new, _params) do
     # Default to UTC if the user hasn't set the timezone setting.
-    timezone = case socket.assigns.current_user.timezone do
-      nil -> "UTC"
-      tz -> tz
-    end
+    timezone =
+      case socket.assigns.current_user.timezone do
+        nil -> "UTC"
+        tz -> tz
+      end
 
     # Default the new item's due date to today.
     today = DateTime.to_date(Timex.now(timezone))

--- a/lib/todo_web/live/item_live/index.ex
+++ b/lib/todo_web/live/item_live/index.ex
@@ -31,9 +31,14 @@ defmodule TodoWeb.ItemLive.Index do
   end
 
   defp apply_action(socket, :new, _params) do
+    # Default the new item's due date to today.
+    timezone = socket.assigns.current_user.timezone
+    today = DateTime.to_date(Timex.now(timezone))
+    item = %Item{due_date: today}
+
     socket
     |> assign(:page_title, "New Item")
-    |> assign(:item, %Item{})
+    |> assign(:item, item)
   end
 
   defp apply_action(socket, :index, _params) do


### PR DESCRIPTION
The current date is a reasonable default for this field on a to-do item.