### PR TITLE
Remove whitespace so user can view more to-dos simultaneously

### DIFF
--- a/lib/todo_web/live/item_live/item_component.html.heex
+++ b/lib/todo_web/live/item_live/item_component.html.heex
@@ -1,7 +1,7 @@
-<div id={"item-#{@item.id}"} class='flex flex-col w-1/2 md:w-1/3 lg:w-1/4 m-2 border-solid border-2 border-black rounded-md'>
+<div id={"item-#{@item.id}"} class='flex flex-row w-full md:w-1/2 lg:w-1/3 m-1 border-solid border-2 border-black rounded-sm'>
   <div class='m-2'>
     <div><%= @item.description %></div>
-    <div class='mt-1'>
+    <div>
       <strong>Due</strong>
       <span class={ItemComponent.compare_date(@item.due_date, @timezone)}> 
         <%= Todo.Date.pretty_date(@item.due_date) %>
@@ -9,7 +9,6 @@
     </div>
   </div>
   <div class='flex flex-row grow'>
-    <div class='justify-start m-2 self-end'><%= Item.pretty_status(@item) %></div>
     <div class='flex flex-row grow justify-end self-end m-2'>
       <div class='mr-2'><%= live_patch "Edit", to: Routes.item_index_path(@socket, :edit, @item) %></div>
       <div><%= link "Delete", to: "#", phx_click: "delete", phx_value_id: @item.id, data: [confirm: "Are you sure?"] %></div>


### PR DESCRIPTION
This PR removes whitespace so that the user can see more to-do items at one time.

We no longer display the `Status` field on the to-do item since it isn't really necessary. I just delete the to-do item when I finish it (or don't need it anymore).